### PR TITLE
Add Pyrexp to "Other Non-specific Tools" - softwares.md

### DIFF
--- a/extras/extras BioInformatics/softwares.md
+++ b/extras/extras BioInformatics/softwares.md
@@ -46,6 +46,7 @@
 * [RegEx Generator](http://www.regexr.com/)
 * [RegEx 101](https://regex101.com/)
 * [RegEx Debugger](https://www.debuggex.com/)
+* [Pyrexp](https://pythonium.net/regex)
 * [Plotly](https://plot.ly/)
 * [Small (bioinformatic) Tools Manifesto](https://github.com/pjotrp/bioinformatics)
 * [Terminal Multiplexer](https://robots.thoughtbot.com/a-tmux-crash-course)


### PR DESCRIPTION
Add Pyrexp (my tool), an online visual regex tester, to "Other Non-specific Tools" - softwares.md